### PR TITLE
Save table settings into localStorage based on path

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ yarn add carpentr
 ```js
 import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
-import { Carpentr } from 'carpentr'
+import { useCarpentr } from 'carpentr'
 
 const Users = () => {
 const data = [
@@ -37,7 +37,7 @@ const data = [
   { firstName: 'Sloane', lastName: 'Peterson', dob: '6-19-1967', occupation: 'student' }
 ]
 
-  const payload = Carpentr({
+  const payload = useCarpentr({
     initialData: data,
     sortColumn: 'firstName',
     searchKeys: ['firstName', 'lastName']
@@ -162,7 +162,7 @@ This is the array of data you wish to put into a table format. If your data is c
 ```js
   const data = [...users] 
 
-  const payload = Carpentr({ initialData: data })
+  const payload = useCarpentr({ initialData: data })
 ```
 
 
@@ -172,7 +172,7 @@ You will be given a method in the next section called `setSearchTerm` that will 
 ```js
   const data = [...users]
 
-  const payload = Carpentr({
+  const payload = useCarpentr({
     initialData: data,
     searchKeys: ['firstName', 'lastName']
   })
@@ -185,7 +185,7 @@ If you know in advance what column you wish to sort on then you can pass that in
 ```js
   const data = [...users]
 
-  const payload = Carpentr({
+  const payload = useCarpentr({
     initialData: data,
     searchKeys: ['firstName', 'lastName'],
     sortColumn: 'lastName'
@@ -199,7 +199,7 @@ By default Carpentr will sort your data in `asc` (ascending order). If you wish 
 ```js
   const data = [...users]
 
-  const payload = Carpentr({
+  const payload = useCarpentr({
     initialData: data,
     searchKeys: ['firstName', 'lastName'],
     sortColumn: 'lastName',
@@ -215,7 +215,7 @@ If for some reason you don't want the table to start on the first page of result
   const data = [...users]
   const { currentPage } = useParams()
 
-  const payload = Carpentr({
+  const payload = useCarpentr({
     initialData: data,
     searchKeys: ['firstName', 'lastName'],
     sortColumn: 'lastName',
@@ -231,17 +231,17 @@ Carpentr will provide to you the pagination logic for your tables. Here is your 
 ```js
   const data = [...users]
 
-  const payload = Carpentr({
+  const payload = useCarpentr({
     initialData: data,
     pageNeighbors: 1 // will give you: [1, 2, 3]
   })
 
-  const payload = Carpentr({
+  const payload = useCarpentr({
     initialData: data,
     pageNeighbors: 2 // will give you: [1, 2, 3, 4, 5]
   })
 
-  const payload = Carpentr({
+  const payload = useCarpentr({
     initialData: data,
     pageNeighbors: 3 // will give you: [1, 2, 3, 4, 5, 6, 7]
   })
@@ -254,7 +254,7 @@ By default Carpentr will return the first 10 results to you to display on the sc
 ```js
   const data = [...users]
 
-  const payload = Carpentr({
+  const payload = useCarpentr({
     initialData: data,
     resultSet: 20
   })
@@ -262,7 +262,7 @@ By default Carpentr will return the first 10 results to you to display on the sc
 
 
 ## The Payload
-By running `Carpentr({...options})` you are returned a Payload with all of the values and helper methods you need to manage your Table.
+By running `useCarpentr({...options})` you are returned a Payload with all of the values and helper methods you need to manage your Table.
 
 |Props                |Type   	    |
 |---	                |---	        |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "carpentr",
   "description": "Data Tables made easy",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "license": "MIT",
   "author": "William Pruden <williamprudeniv@gmail.com>",
   "repository": {
@@ -61,8 +61,8 @@
     "eslint-plugin-react-hooks": "2.3.0",
     "eslint-plugin-standard": "4.0.1",
     "jest": "24.9.0",
-    "react": "16.8.6",
-    "react-dom": "16.8.6",
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
     "rollup": "1.26.0",
     "rollup-plugin-analyzer": "3.2.2",
     "rollup-plugin-babel": "4.3.3",
@@ -72,5 +72,8 @@
     "rollup-plugin-svg": "2.0.0",
     "rollup-plugin-terser": "5.1.2",
     "rollup-plugin-uglify": "6.0.4"
+  },
+  "dependencies": {
+    "use-deep-compare-effect": "1.3.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -750,6 +750,13 @@
     "@babel/plugin-transform-react-jsx-self" "^7.0.0"
     "@babel/plugin-transform-react-jsx-source" "^7.0.0"
 
+"@babel/runtime@^7.7.2":
+  version "7.10.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.5.tgz#303d8bd440ecd5a491eae6117fd3367698674c5c"
+  integrity sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.8.4":
   version "7.10.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.2.tgz#d103f21f2602497d38348a32e008637d506db839"
@@ -1014,6 +1021,19 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.12.tgz#9c1d8ffb8084e8936603a6122a7649e40e68e04b"
   integrity sha512-/sjzehvjkkpvLpYtN6/2dv5kg41otMGuHQUt9T2aiAuIfleCQRQHXXzF1eAw/qkZTj5Kcf4JSTf7EIizHocy6Q==
 
+"@types/prop-types@*":
+  version "15.7.3"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
+  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
+"@types/react@*":
+  version "16.9.43"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.43.tgz#c287f23f6189666ee3bebc2eb8d0f84bcb6cdb6b"
+  integrity sha512-PxshAFcnJqIWYpJbLPriClH53Z2WlJcVZE+NP2etUtWQs2s7yIMj3/LDKZT/5CHJ/F62iyjVCDu2H3jHEXIxSg==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
 "@types/resolve@0.0.8":
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"
@@ -1025,6 +1045,13 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/use-deep-compare-effect@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/use-deep-compare-effect/-/use-deep-compare-effect-1.2.0.tgz#d55d9bda6fea5ff7c93038c53052db1b3145f5d9"
+  integrity sha512-2uNqaSobMvUTGR7G72tUHDX+Kx341q25OuM0m2B6VID7eljIvYuDaFTKfmDnbvej67yEhCc35zA6dmIYriwOXA==
+  dependencies:
+    "@types/react" "*"
 
 "@types/yargs-parser@*":
   version "15.0.0"
@@ -1781,6 +1808,11 @@ cssstyle@^1.0.0:
   dependencies:
     cssom "0.3.x"
 
+csstype@^2.2.0:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.11.tgz#452f4d024149ecf260a852b025e36562a253ffc5"
+  integrity sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw==
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -1859,6 +1891,11 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
+dequal@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-1.0.1.tgz#dbbf9795ec626e9da8bd68782f4add1d23700d8b"
+  integrity sha512-Fx8jxibzkJX2aJgyfSdLhr9tlRoTnHKrRJuu2XHlAgKioN2j19/Bcbe0d4mFXYZ3+wpE2KVobUVTfDutcD17xQ==
 
 detect-newline@^2.1.0:
   version "2.1.0"
@@ -5154,6 +5191,15 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
+
+use-deep-compare-effect@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/use-deep-compare-effect/-/use-deep-compare-effect-1.3.1.tgz#90bdbed97e1acb8423f7bb0bf24de58590d021af"
+  integrity sha512-ejL+Al+aeDyC9Sywx56ti4PtSwkf6BH27tEptMWF2cfO41/auG0nRRsArh6Vv5bUyBe3z7IyxmgQCK5nas70hg==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    "@types/use-deep-compare-effect" "^1.2.0"
+    dequal "^1.0.0"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
- updated version to 1.0.6
- add `ls`, `path`, and `saveSettings` props to work with localStorage from inside the hook
- can save `search`, `sortOrder`, `sortColumn`, `currentPage`, and `resultSet` values
- updated Carpentr -> useCarpentr
- added use-deep-compare-effect 1.3.1 as a dependency (updated react and react-dom to 16.13.1, since that package asks for react@>=16.12)